### PR TITLE
Omission of function rank

### DIFF
--- a/R/basic-data-wrangling.Rmd
+++ b/R/basic-data-wrangling.Rmd
@@ -198,7 +198,7 @@ data(murders)
 
     ```{r}
 library(dplyr)
-murders <- mutate(murders, rate =  total / population * 100000, rank = (-rate))
+murders <- mutate(murders, rate =  total / population * 100000, rank = rate(-rate))
     ```
 
     in the solution to the previous exercise we did the following:


### PR DESCRIPTION
Just added the function rank in the exercise. When the function is not there, the rank was only the rate multiplied by -1.