### PR TITLE
Load ggplot2 to enable independent knitting

### DIFF
--- a/prob/discrete-probability.Rmd
+++ b/prob/discrete-probability.Rmd
@@ -1,3 +1,7 @@
+```{r}
+library(ggplot2)
+```
+
 # Discrete probability
 
 We start by covering some basic principles related to categorical data. The subset of probability is referred to as _discrete probability_. It will help us understand the probability theory we will later introduce for numeric and continuous data, which is much more common in data science applications. Discrete probability is more useful in card games and therefore we use these as examples.

--- a/prob/discrete-probability.Rmd
+++ b/prob/discrete-probability.Rmd
@@ -1,4 +1,4 @@
-```{r}
+```{r, echo = FALSE}
 library(ggplot2)
 ```
 


### PR DESCRIPTION
On attempting to knit this file, it failed at the point of calls to
`qplot()`. This was probably missed because ggplot2 would have been loaded
into the session at the time it was knitted by other users. It's not hard
to imagine that the package would have been loaded by other .Rmd files in
the book. But if one wants to build this page ALONE, it fails. So I
propose a change wherein we call `library(ggplot2)`.