### PR TITLE
Fixing values in Monte Carlo problem set to be internally consistent.

### DIFF
--- a/prob/random-variables-sampling-models-clt.Rmd
+++ b/prob/random-variables-sampling-models-clt.Rmd
@@ -433,7 +433,7 @@ So be careful when using the `sd` function in R. However, keep in mind that thro
 8. What is the probability that you end up winning money? Hint: use the CLT.
 
 
-9. Create a Monte Carlo simulation that generates 10,000 outcomes of $S$. Compute the average and standard deviation of the resulting list to confirm the results of 6 and 7. Start your code by setting the seed to 1 with `set.seed(1)`.
+9. Create a Monte Carlo simulation that generates 1,000 outcomes of $S$. Compute the average and standard deviation of the resulting list to confirm the results of 6 and 7. Start your code by setting the seed to 1 with `set.seed(1)`.
 
 
 
@@ -442,7 +442,7 @@ So be careful when using the `sd` function in R. However, keep in mind that thro
 
 11. The Monte Carlo result and the CLT approximation are close, but not that close. What could account for this?
     
-    A. 10,000 simulations is not enough. If we do more, they match.
+    A. 1,000 simulations is not enough. If we do more, they match.
     
     B. The CLT does not work as well when the probability of success is small. In this case, it was 1/19. If we make the number of roulette plays bigger, they will match better.
 
@@ -451,7 +451,7 @@ So be careful when using the `sd` function in R. However, keep in mind that thro
     D. The CLT only works for the averages.
 
 
-12. Now create a random variable $Y$ that is your average winnings per bet after playing off your winnings after betting on green 10,000 times.
+12. Now create a random variable $Y$ that is your average winnings per bet after playing off your winnings after betting on green 1,000 times.
 
 13. What is the expected value of $Y$?
 
@@ -470,9 +470,9 @@ So be careful when using the `sd` function in R. However, keep in mind that thro
 
     A. We are now computing averages instead of sums.
     
-    B. 2,500 Monte Carlo simulations is not better than 10,000.
+    B. 2,500 Monte Carlo simulations is not better than 1,000.
     
-    C. The CLT does works better when the sample size is larger. We increased from 1,000 to 10,000.
+    C. The CLT works better when the sample size is larger. We increased from 1,000 to 2,500.
     
     D. It is not closer. The difference is within rounding error.
 


### PR DESCRIPTION
Making problem set internally consistent (and the questions answerable) by standardizing B=1000 and B=2500 as comparison values. Previous versions jumped between three values of 1000, 2500, 10000 making references to previous problems unable to be clearly answered.

If you don't think these top/bottom values are the best for the answer you hope students to obtain, let me know or thoroughly check values for all problems in this set. Reading the problems, it looks like they were intended to use 1000 and 2500.

Thanks!