### PR TITLE
Adding example of list without variable names.

### DIFF
--- a/R/R-basics.Rmd
+++ b/R/R-basics.Rmd
@@ -483,6 +483,16 @@ record
 class(record)
 ```
 
+You might also encounter lists without variable names:
+
+```{r, echo=FALSE}
+record <- list("John Doe",
+             1234,
+             c(95, 82, 91, 97, 93),
+             "A")
+record
+```
+
 We won't be using lists until later, but you might encounter one in your own exploration of R. For this reason, we show you some basics here. 
 
 As with data frames, you can extract the components of a list with the accessor `$`. In fact, data frames are a type of list.


### PR DESCRIPTION
The current list example includes variable names that can be accessed with `$`. However, students will also encounter lists without assigned names that have entries listed as [[1]], etc. It would be helpful to have a visual example of a list in this format as well.

Below the original list example, I add a modified version of that example without variable names to display the other common visual appearance of lists.