### PR TITLE
Correct `get_slope()` function

### DIFF
--- a/regression/linear-models.Rmd
+++ b/regression/linear-models.Rmd
@@ -5,7 +5,7 @@ Previously, we noted a strong relationship between Runs and BB. If we find the r
 ```{r, warning=FALSE, message=FALSE}
 library(tidyverse)
 library(Lahman)
-get_slope <- function(x, y) cor(x, y) / (sd(x) * sd(y))
+get_slope <- function(x, y) cor(x, y) * (sd(x) / sd(y))
 
 bb_slope <- Teams %>% 
   filter(yearID %in% 1961:2001 ) %>% 


### PR DESCRIPTION
The previous `get_slope()` function was not calculating the slope of the regression line correctly, so the textbook disagreed with the videos (which pull the slope from `lm()`.) Correcting the formula to this format gives the same results as `lm()`.

Rafa, wanted to run this past you in case I messed something up.