### PR TITLE
Adding missing `type="response"` to `predict()`

### DIFF
--- a/ml/regression.Rmd
+++ b/ml/regression.Rmd
@@ -387,7 +387,7 @@ with $g(p) = \log \frac{p}{1-p}$ the logistic function described in the previous
 
 ```{r}
 fit_glm <- glm(y ~ x_1 + x_2, data=mnist_27$train, family = "binomial")
-p_hat_glm <- predict(fit_glm, mnist_27$test)
+p_hat_glm <- predict(fit_glm, mnist_27$test, type="response")
 y_hat_glm <- factor(ifelse(p_hat_glm > 0.5, 7, 2))
 confusionMatrix(y_hat_glm, mnist_27$test$y)$overall["Accuracy"]
 ```


### PR DESCRIPTION
In the section "Logistic regression with more than one predictor", [line 390](https://github.com/rafalab/dsbook/blob/31dc2baea194ec78d4cadf76e213a68cb380e499/ml/regression.Rmd#L390) calculateed `p_hat_glm` with `predict()` but omitted `type="response"`. As a result, `p_hat_glm` did not contain probabilities from 0 to 1 but ranged from -4.3 to 5.19. This means the `y_hat_glm` and accuracy calculations were incorrect.

Adding the argument `type="response"` to `predict()` fixes the issue.

Note that later work with these predictions, such as line 413, already use `type="response"`.

Rafa, I'm adding this as a PR rather than committing directly because I know you're keeping track of all the issues in the current version of the book.