### PR TITLE
wrangling(string-processing): fix pdf url

### DIFF
--- a/wrangling/string-processing.Rmd
+++ b/wrangling/string-processing.Rmd
@@ -1086,7 +1086,7 @@ We could extract the numbers by hand, but this could lead to human error. Instea
 ```{r, eval=FALSE}
 library("pdftools")
 temp_file <- tempfile()
-url <- paste0("http://www.pnas.org/content/suppl/2015/09/16/",
+url <- paste0("https://www.pnas.org/content/suppl/2015/09/16/",
               "1510159112.DCSupplemental/pnas.201510159SI.pdf")
 download.file(url, temp_file)
 txt <- pdf_text(temp_file)


### PR DESCRIPTION
`download.file` does not follow redirects

```
curl -v "http://www.pnas.org/content/suppl/2015/09/16/1510159112.DCSupplemental/pnas.201510159SI.pdf"
*   Trying 104.16.154.14...
* TCP_NODELAY set
* Connected to www.pnas.org (104.16.154.14) port 80 (#0)
> GET /content/suppl/2015/09/16/1510159112.DCSupplemental/pnas.201510159SI.pdf HTTP/1.1
> Host: www.pnas.org
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Date: Sat, 29 Feb 2020 16:26:12 GMT
< Cache-Control: max-age=3600
< Expires: Sat, 29 Feb 2020 17:26:12 GMT
< Location: https://www.pnas.org/content/suppl/2015/09/16/1510159112.DCSupplemental/pnas.201510159SI.pdf
< X-Content-Type-Options: nosniff
< Server: cloudflare
< CF-RAY: 56cbffa28ecb3c3f-CDG
< X-Cache: MISS from controller.access.network
< X-Cache-Lookup: MISS from controller.access.network:3128
< Transfer-Encoding: chunked
< Connection: keep-alive
<
* Connection #0 to host www.pnas.org left intact
```