### PR TITLE
Fixing mistake in Unix chapter

### DIFF
--- a/productivity/unix.Rmd
+++ b/productivity/unix.Rmd
@@ -377,7 +377,7 @@ or this:
 
 ```{bash, eval=FALSE}
 cd ~/docs/reports/
-mv ../cv.tex ./
+mv ../resumes/cv.tex ./
 ```
 
 Notice that in the last one we used the working directory shortcut `.` to give a relative path as the destination directory.


### PR DESCRIPTION
To move the file cv.tex from resumes to reports, resumes folder needs to be specified in the last example. Otherwise it would expect file cv.tex in the docs folder. This typo is also in the EDX lesson.