### PR TITLE
correctly define example interval

### DIFF
--- a/inference/confidence-intervals-p-values.Rmd
+++ b/inference/confidence-intervals-p-values.Rmd
@@ -23,7 +23,7 @@ We can use the statistical theory we have learned to compute the probability of 
 
 When a pollster reports an estimate and a margin of error, they are, in a way, reporting a 95\% confidence interval. Let's show how this works mathematically. 
 
-We want to know the probability that the interval $[\bar{X} - 2\hat{\mbox{SE}}(\bar{X}), \bar{X} - 2\hat{\mbox{SE}}(\bar{X})]$ contains the true proportion $p$. First, consider that the start and end of these intervals are random variables: every time we take a sample, they change. To illustrate this, run the Monte Carlo simulation above twice. We use the same parameters as above:
+We want to know the probability that the interval $[\bar{X} - 2\hat{\mbox{SE}}(\bar{X}), \bar{X} + 2\hat{\mbox{SE}}(\bar{X})]$ contains the true proportion $p$. First, consider that the start and end of these intervals are random variables: every time we take a sample, they change. To illustrate this, run the Monte Carlo simulation above twice. We use the same parameters as above:
 
 ```{r}
 p <- 0.45


### PR DESCRIPTION
Add 2*SE instead of subtracting it to get the upper bound of the interval.

---

Thanks a lot for your work! Found this small mistake in the book.