### PR TITLE
 Recommendation Systems: RMSE formula for regularized bias

### DIFF
--- a/ml/recommendation-systems.Rmd
+++ b/ml/recommendation-systems.Rmd
@@ -427,7 +427,7 @@ $$
 
 Suppose we know the average rating is, say, $\mu = 3$. If we use least squares, the estimate for the first movie effect $b_1$ is the average of the 100 user ratings, $1/100 \sum_{i=1}^{100} (Y_{i,1} - \mu)$, which we expect to be a quite precise. However, the estimate for movies 2, 3, 4, and 5 will simply be the observed deviation from the average rating $\hat{b}_i = Y_{u,i} - \hat{\mu}$ which is an estimate based on just one number so it won't be precise at all. Note these estimates  make the error $Y_{u,i} - \mu + \hat{b}_i$ equal to 0 for $i=2,3,4,5$, but this is a case of over-training. In fact, ignoring the one user and guessing that movies 2,3,4, and 5 are just average movies ($b_i = 0$) might provide a better prediction. The general idea of penalized regression is to control the total variability of the movie effects: $\sum_{i=1}^5 b_i^2$. Specifically, instead of minimizing the least squares equation, we minimize an equation that adds a penalty:
 
-$$\frac{1}{N} \sum_{u,i} \left(y_{u,i} - \mu - b_i\right)^2 + \lambda \sum_{i} b_i^2$$
+$$\frac{1}{N} \left( \sum_{u,i} \left(y_{u,i} - \mu - b_i\right)^2 + \lambda \sum_{i} b_i^2\right)$$
 The first term is just least squares and the second is a penalty that gets larger when many $b_i$ are large. Using calculus we can actually show that the values of $b_i$ that minimize this equation are:
 
 $$
@@ -531,8 +531,8 @@ However, while we show this as an illustration, in practice we should be using f
 We can use regularization for the estimate user effects as well. We are minimizing:
 
 $$
-\frac{1}{N} \sum_{u,i} \left(y_{u,i} - \mu - b_i - b_u \right)^2 + 
-\lambda \left(\sum_{i} b_i^2 + \sum_{u} b_u^2\right)
+\frac{1}{N} \left(\sum_{u,i} \left(y_{u,i} - \mu - b_i - b_u \right)^2 + 
+\lambda \left(\sum_{i} b_i^2 + \sum_{u} b_u^2\right)\right)
 $$
 
 The estimates that minimize this can be found similarly to what we did above. Here we use cross-validation to pick a $\lambda$:


### PR DESCRIPTION
To compute bi value to minimize the formula : MSE = 1/N ∑ (y - mu - bi)^2 + λ ∑ bi^2, with calculus on fixed term bi:

∆ MSE/∆ bi =-2/N ∑(y - mu - bi) + 2λ bi 


           = -2/N ∑(y - mu) + 2bi ni/N +  2λ bi 

           = 2(λ + ni/N)bi - 2∑(y - mu)/N 
The minimum is when the the derivation is null, so:

bi =  ∑(y - mu)/(N * (λ + ni/N)) = ∑(y - mu)/(Nλ + ni)

It's different from the result in the document (and the other supports) :  ∑(y - mu)/(λ + ni)
if λ  is divided by N, the MSE formula will be: MSE = 1/N ∑ (y - mu - bi)^2 + λ/N ∑ bi^2

The derivation of this formula give us the exact result as in your material: bi= ∑(y - mu)/(λ + ni)
The same for the RMSE formula with both movies and users bias
See attached print screen. 
For more detail, you find attached my report for a MovieLens Recommendation system, chapter "3.6 Regularization"
![Screen Shot 2020-08-29 at 1 35 29 PM](https://user-images.githubusercontent.com/48100301/91642837-93dd3680-e9fc-11ea-9502-23f2105d7456.png)

[movielens_report_v1.0.pdf](https://github.com/rafalab/dsbook/files/5145712/movielens_report_v1.0.pdf)
