### PR TITLE
include missing library

### DIFF
--- a/ml/intro-ml.Rmd
+++ b/ml/intro-ml.Rmd
@@ -24,6 +24,7 @@ For example, in the digit reader data, $K=10$ with the classes being the digits 
 The general setup is as follows. We have a series of features and an unknown outcome we want to predict:
 
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
+library(tibble)
 library(tidyverse)
 library(knitr)
 library(dslabs)


### PR DESCRIPTION
At least when running from an interactive R session, the tibble library is not imported by default. Please close the PR if this is a non-issue for you.